### PR TITLE
ci: add PHP/Python lint + Semgrep PHP SAST (no CI existed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+# csl-apidev is the CDSL web-backend: plain PHP API endpoints plus Python/JS
+# tooling. There is no Composer/npm/Mako project here, so CI lints what exists:
+#   - PHP syntax (php -l) on first-party PHP — hard gate
+#   - Python lint (ruff, warn-only — roughly half the .py files are legacy
+#     Python 2 and will not parse under Python 3)
+#   - YAML lint
+# Vendored / intentional-fixture / broken legacy-variant PHP is skipped and the
+# skips are logged (no silent gaps).
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  php-lint:
+    name: PHP syntax lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          coverage: none
+      - name: php -l on first-party PHP
+        run: |
+          fail=0; linted=0; skipped=0
+          while IFS= read -r f; do
+            case "$f" in
+              phpquery/*)                                                      # vendored third-party library
+                echo "skip (vendor): $f"; skipped=$((skipped+1)); continue;;
+              htmlwork/makeassets/bad.php)                                     # intentional bad-input fixture
+                echo "skip (fixture): $f"; skipped=$((skipped+1)); continue;;
+              simple-search/v1.0d/simple_search.php|simple-search/v1.1a/simple_search.php)
+                echo "skip (legacy variant): $f"; skipped=$((skipped+1)); continue;;  # pre-existing PHP8 syntax errors
+            esac
+            if ! php -l "$f" >/dev/null 2>lint.err; then
+              echo "::error file=$f::$(tr '\n' ' ' < lint.err)"; fail=1
+            fi
+            linted=$((linted+1))
+          done < <(git ls-files '*.php')
+          echo "php -l: linted=$linted skipped=$skipped"
+          exit $fail
+
+  python-lint:
+    name: Python lint (warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - name: Ruff (warn-only — repo contains legacy Python 2 scripts)
+        run: ruff check . || echo "::warning::ruff reported findings (includes legacy Python 2)"
+
+  yaml-lint:
+    name: YAML lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - run: pip install pyyaml
+      - run: |
+          python - <<'PY'
+          import sys, glob, yaml
+          fail = 0
+          for f in glob.glob('**/*.yml', recursive=True) + glob.glob('**/*.yaml', recursive=True):
+              if '.git' in f:
+                  continue
+              try:
+                  with open(f, encoding='utf-8') as fh:
+                      yaml.safe_load(fh)
+              except yaml.YAMLError as e:
+                  print(f'::error file={f}::{e}'); fail = 1
+          sys.exit(fail)
+          PY

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,45 @@
+name: Semgrep
+
+# csl-apidev has executable PHP + Python (+ JS) but no SAST. CodeQL has no PHP
+# analyzer, so Semgrep — which does — is the right fit, and it also covers the
+# Python tooling. It scans with the community security rulesets and uploads
+# results to the repo's Security tab. Non-blocking.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    # The semgrep container ships its own toolchain; skip on Dependabot (no token).
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/php \
+            --config p/python \
+            --config p/security-audit \
+            --sarif --output semgrep.sarif \
+            --metrics off || true
+
+      - name: Upload SARIF to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary

csl-apidev shipped **87 PHP, 31 Python, and 42 JS files with no CI and no SAST** — the only workflows were [`dependabot-auto-merge.yml`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/.github/workflows/dependabot-auto-merge.yml) and [`readme-guard.yml`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/.github/workflows/readme-guard.yml). This adds the same protection [csl-websanlexicon#64](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/64) added there, adapted to this repo (plain PHP — no Composer/npm/Mako).

### `ci.yml`

| Job | Gate | What |
|---|---|---|
| **php-lint** | hard | `php -l` over first-party PHP (`git ls-files '*.php'`). Skips + logs a small denylist of pre-existing non-compiling files. **82 files lint clean.** |
| **python-lint** | warn-only | `ruff`. ~half the `.py` files are **legacy Python 2** (`print` statements), so this is intentionally non-blocking. |
| **yaml-lint** | hard | parse all YAML. |

The php-lint skip-list (each logged, not silent):
- `phpquery/` — vendored third-party library
- `htmlwork/makeassets/bad.php` — intentional bad-input fixture
- `simple-search/v1.0d/simple_search.php`, `simple-search/v1.1a/simple_search.php` — pre-existing PHP 8 syntax errors in dev/alpha variants (the `v1.0`/`v1.1` mainline versions lint clean)

### `semgrep.yml`

CodeQL has no PHP analyzer, so the PHP backend would get zero SAST. Semgrep does support PHP (and Python): it scans `p/php` + `p/python` + `p/security-audit` and uploads SARIF to the Security tab. Non-blocking, weekly schedule — mirrors the csl-websanlexicon setup. This guards the `dal.php` / `getword.php` security fixes in [#49](https://github.com/sanskrit-lexicon/csl-apidev/pull/49) from regressing.

### Verification

- Local `php -l` (PHP 8.2.12): php-lint green — `linted=82, skipped=5`.
- Both workflow files are valid YAML.

### Not included (possible follow-ups)
- JS is left out of Semgrep for now (the 42 `.js` files include vendored libs that would add noise); easy to add `p/javascript` later.
- A CodeQL workflow (Python + JS, the languages CodeQL supports here) could complement Semgrep, but Semgrep already covers the security-critical PHP that CodeQL cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
