### PR TITLE
fix: harden basicdisplay.php XML parse-error path (propagate websanlexicon #65)

### DIFF
--- a/basicdisplay.php
+++ b/basicdisplay.php
@@ -124,10 +124,16 @@ public function __construct($key,$string_or_array,$filterin,$dict) {
   dbgprint($this->dbg,"chk 1\n");
   // parse
   if (!xml_parse($p,$line)) {
-   dbgprint(true,"basicdisplay.php: xml parse error\nline=$line\n");
+   // Respect the debug flag: previously this forced dbgprint(true,...) on
+   // every malformed entry, which silently appended the raw record to the
+   // repo-root dbg_apidev.txt log in production. Keep diagnostics behind $dbg.
+   dbgprint($this->dbg,"basicdisplay.php: xml parse error\nline=$line\n");
    $row = $line;
    $this->status = false;
-   $this->html = "<p>basicdisplay.php: xml parse error</p>";
+   // User-facing fallback: don't leak the internal filename, and don't blank
+   // the entry — show its text with markup stripped so a single bad record
+   // degrades gracefully instead of breaking the display.
+   $this->html = "<p>" . htmlspecialchars(strip_tags($line)) . "</p>";
    return;
   }
   dbgprint($this->dbg,"chk 2\n");


### PR DESCRIPTION
## Summary

Propagates the `basicdisplay.php` parse-error hardening from [csl-websanlexicon#65](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/65) to this repo. [`basicdisplay.php`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/basicdisplay.php) is a module **shared** between the two repos (see [csl-websanlexicon `v02/apidev_copy.sh`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/apidev_copy.sh)); this copy still had the unhardened branch.

When PHP's `xml_parse()` fails on a malformed record, the old code:
- **forced `dbgprint(true, …)`** on every failure — silently appending the raw record to the repo-root `dbg_apidev.txt` log in production (`dbg_apidev.txt` is already gitignored here, but the write still happens). Now respects `$this->dbg`.
- showed a **filename-leaking error** (`basicdisplay.php: xml parse error`) and blanked the entry. Now a graceful `strip_tags()` + `htmlspecialchars()` fallback, so the record's text still displays instead of breaking.

### Verification
- `php -l` clean (PHP 8.2.12).
- This repo now has CI (#50), so php-lint + Semgrep run on this PR.

This completes the shared-module sync started by [#49](https://github.com/sanskrit-lexicon/csl-apidev/pull/49) (`dal.php` / `getword.php`); `basicadjust.php` and `getword_data.php` are the other shared modules and currently match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
