### PR TITLE
Security: close JSONP-callback reflected-XSS across 10 endpoints

### DIFF
--- a/api_trial.php
+++ b/api_trial.php
@@ -19,7 +19,16 @@ function getapiCall($url) {
   #print_r($table1);
   if (isset($_GET['callback'])) {
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
+   echo htmlentities($callback) . "($json)";
   }else {
    echo json_encode($table1);
   }

--- a/dalglob.php
+++ b/dalglob.php
@@ -14,7 +14,16 @@ function dalglobCall() {
   $ans = $dal->ans;
   $json = json_encode($ans);
   if (isset($_GET['callback'])) {
-   echo "{$_GET['callback']}($json)";
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
+   echo htmlentities($callback) . "($json)";
    //dbgprint(true,"dalglobCall: Returned json\n");
   }else {
    echo $json;

--- a/getsuggest.php
+++ b/getsuggest.php
@@ -14,7 +14,16 @@ function getsuggestCall() {
   Ref: //www.geekality.net/2010/06/27/php-how-to-easily-provide-json-and-jsonp/
  */
  if (isset($_GET['callback'])) {
-  echo "{$_GET['callback']}($json)";
+  $callback = $_GET['callback'];
+  // Only allow a safe JSONP callback identifier. Echoing the raw callback
+  // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+  if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+   header('content-type: text/plain; charset=utf-8');
+   http_response_code(400);
+   echo "invalid callback";
+   return;
+  }
+  echo htmlentities($callback) . "($json)";
  }else {
   echo $json;
  }

--- a/getword.php
+++ b/getword.php
@@ -23,7 +23,7 @@ function getwordCall() {
     return;
    }
    $json = json_encode($table1);
-   echo "{$callback}($json)";
+   echo htmlentities($callback) . "($json)";
   }else {
    echo $table1;
   }

--- a/getword_xml.php
+++ b/getword_xml.php
@@ -16,7 +16,16 @@ function getwordXmlCall() {
   $temp = new GetwordXmlClass();
   $json = $temp->json;
   if (isset($_GET['callback'])) {
-   echo "{$_GET['callback']}($json)";
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
+   echo htmlentities($callback) . "($json)";
   }else {
    echo $json;
   }

--- a/listhier.php
+++ b/listhier.php
@@ -14,7 +14,16 @@ function listhierCall() {
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
+   echo htmlentities($callback) . "($json)";
   }else {
    echo $table1;
   }

--- a/pwkvn/01/getsuggest.php
+++ b/pwkvn/01/getsuggest.php
@@ -14,7 +14,16 @@ function getsuggestCall() {
   Ref: //www.geekality.net/2010/06/27/php-how-to-easily-provide-json-and-jsonp/
  */
  if (isset($_GET['callback'])) {
-  echo "{$_GET['callback']}($json)";
+  $callback = $_GET['callback'];
+  // Only allow a safe JSONP callback identifier. Echoing the raw callback
+  // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+  if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+   header('content-type: text/plain; charset=utf-8');
+   http_response_code(400);
+   echo "invalid callback";
+   return;
+  }
+  echo htmlentities($callback) . "($json)";
  }else {
   echo $json;
  }

--- a/pwkvn/02/getsuggest.php
+++ b/pwkvn/02/getsuggest.php
@@ -14,7 +14,16 @@ function getsuggestCall() {
   Ref: //www.geekality.net/2010/06/27/php-how-to-easily-provide-json-and-jsonp/
  */
  if (isset($_GET['callback'])) {
-  echo "{$_GET['callback']}($json)";
+  $callback = $_GET['callback'];
+  // Only allow a safe JSONP callback identifier. Echoing the raw callback
+  // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+  if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+   header('content-type: text/plain; charset=utf-8');
+   http_response_code(400);
+   echo "invalid callback";
+   return;
+  }
+  echo htmlentities($callback) . "($json)";
  }else {
   echo $json;
  }

--- a/pwkvn/03/getsuggest.php
+++ b/pwkvn/03/getsuggest.php
@@ -14,7 +14,16 @@ function getsuggestCall() {
   Ref: //www.geekality.net/2010/06/27/php-how-to-easily-provide-json-and-jsonp/
  */
  if (isset($_GET['callback'])) {
-  echo "{$_GET['callback']}($json)";
+  $callback = $_GET['callback'];
+  // Only allow a safe JSONP callback identifier. Echoing the raw callback
+  // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+  if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+   header('content-type: text/plain; charset=utf-8');
+   http_response_code(400);
+   echo "invalid callback";
+   return;
+  }
+  echo htmlentities($callback) . "($json)";
  }else {
   echo $json;
  }

--- a/servepdf.php
+++ b/servepdf.php
@@ -23,7 +23,16 @@ function servepdfCall() {
   $table1 = $temp->html;
   if (isset($_GET['callback'])) {
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
+   echo htmlentities($callback) . "($json)";
   }else {
    echo $table1;
   }


### PR DESCRIPTION
## What

Ten endpoints echo the JSONP `callback` straight from `$_GET` into the response body:

```php
echo "{$_GET['callback']}($json)";
```

A JSONP body is served as **JavaScript**, so an attacker-chosen `callback` name is reflected verbatim and executes in the victim's browser — a reflected / JSONP-injection **XSS**. These are the open Semgrep code-scanning [`echoed-request`](https://github.com/sanskrit-lexicon/csl-apidev/security/code-scanning?query=is%3Aopen+rule%3Aphp.lang.security.injection.echoed-request.echoed-request) alerts on `master` that are **not** part of the Salt API PR [#46](https://github.com/sanskrit-lexicon/csl-apidev/pull/46) (which fixed the same class in its own `api1/` files).

## Fix

Apply the hardening **already established in [`getword.php`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/getword.php)** to every site:

1. **Whitelist the callback** against a strict JS-identifier pattern `^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$` and return `400 invalid callback` otherwise. This is the **real control** — `htmlentities` alone does *not* neutralise `(`, `)`, `;` in a JavaScript context.
2. **Wrap the echoed name in `htmlentities()`** for defence-in-depth (and to clear Semgrep's taint sink — the rule is taint-mode, so a `preg_match` guard alone does not satisfy it).

`getword.php` already had the whitelist but still echoed the raw name, so it gets the `htmlentities` wrap too.

## Files (10)

`api_trial.php`, `dalglob.php`, `getsuggest.php`, `getword.php`, `getword_xml.php`, `listhier.php`, `servepdf.php`, `pwkvn/01/getsuggest.php`, `pwkvn/02/getsuggest.php`, `pwkvn/03/getsuggest.php`.

## Verification

- All 10 files pass `php -l`.
- `htmlentities` is a **no-op** on the whitelisted charset `[A-Za-z0-9_$.]`, so legitimate callbacks (`jQuery_123`, `angular.callbacks._0`) are byte-for-byte unaffected; only injection payloads are rejected.
- No raw `echo "{$_GET['callback']}..."` remains in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)